### PR TITLE
Update GitHub Copilot instructions for Cake Pricing app

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,7 +38,7 @@ Keep pricing math out of React components. Implement in backend services or a sh
 ## Endpoints
 - CRUD: /api/ingredients, /api/templates, /api/roles, /api/orders
 - GET /api/settings/pricing
-- PUT /api/settings/pricing  // update margins and roundingRule (must stay "ceil-dollar")
+- PUT /api/settings/pricing  // update margins only; roundingRule is always "ceil-dollar" (not editable)
 - GET /api/pricing/{orderId}?margins=0.2,0.4,0.6
   Returns:
   {


### PR DESCRIPTION
## Summary
- refresh the GitHub Copilot guidelines to match the updated cake pricing domain and workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd9d2ee40c832fb7a21827583c54ce